### PR TITLE
Use reason instead of msg for pytest.skip

### DIFF
--- a/tests/test_zipfile.py
+++ b/tests/test_zipfile.py
@@ -761,11 +761,11 @@ class TestStoredTestsWithSourceFile(AbstractTestsWithSourceFile):
 		try:
 			time.localtime(ts)
 		except OverflowError:
-			pytest.skip(msg=f'time.localtime({ts}) raises OverflowError')
+			pytest.skip(reason=f'time.localtime({ts}) raises OverflowError')
 		try:
 			os.utime(testfn, (ts, ts))
 		except OverflowError:
-			pytest.skip(msg="Host fs cannot set timestamp to required value.")
+			pytest.skip(reason="Host fs cannot set timestamp to required value.")
 
 		mtime_ns = os.stat(tmp_pathplus / TESTFN).st_mtime_ns
 		if mtime_ns != (4386268800 * 10**9):


### PR DESCRIPTION
msg argument is removed since version 8.1.0
https://github.com/pytest-dev/pytest/commit/0591569b4ba9bfb12e5b5307da621a83c4ceced6